### PR TITLE
Fixing a php warning in the _admin_header section

### DIFF
--- a/views/_admin_header.php
+++ b/views/_admin_header.php
@@ -1,9 +1,9 @@
 <div class="wrap wl-settings wikilookup">
 	<h2><?php echo $this->title; ?></h2>
 <?php
-	if ( $_GET[ 'wl_notice' ] === 'success' ) {
+	if ( isset($_GET[ 'wl_notice' ]) && ($_GET[ 'wl_notice' ] === 'success' )) {
 		$this->outputNoticeBox( 'success', __( 'Settings saved successfully', 'wikilookup' ) );
-	} else if ( $_GET[ 'wl_notice' ] === 'fail' ) {
+	} else if ( isset($_GET[ 'wl_notice' ]) && ($_GET[ 'wl_notice' ] === 'fail' )) {
 		$this->outputNoticeBox( 'error', __( 'There was a problem saving settings.', 'wikilookup' ) );
 	}
 ?>


### PR DESCRIPTION
On the admin section a php notice/warning was displayed saying that "wl_notice" was undefined. I've added an isset() check before the value check to make sure to remove the message.